### PR TITLE
Have remove use comparator for compare

### DIFF
--- a/dist/splay.es6.js
+++ b/dist/splay.es6.js
@@ -192,7 +192,8 @@ function remove (i, t, comparator, tree) {
   let x;
   if (t === null) return null;
   t = splay(i, t, comparator);
-  if (i === t.key) {               /* found it */
+  var cmp = comparator(i, t.key);
+  if (cmp === 0) {               /* found it */
     if (t.left === null) {
       x = t.right;
     } else {

--- a/dist/splay.js
+++ b/dist/splay.js
@@ -195,7 +195,8 @@
     var x;
     if (t === null) { return null; }
     t = splay(i, t, comparator);
-    if (i === t.key) {               /* found it */
+    var cmp = comparator(i, t.key);
+    if (cmp === 0) {               /* found it */
       if (t.left === null) {
         x = t.right;
       } else {

--- a/index.js
+++ b/index.js
@@ -183,7 +183,8 @@ function remove (i, t, comparator, tree) {
   let x;
   if (t === null) return null;
   t = splay(i, t, comparator);
-  if (i === t.key) {               /* found it */
+  var cmp = comparator(i, t.key);
+  if (cmp === 0) {               /* found it */
     if (t.left === null) {
       x = t.right;
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "splaytree",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2128,12 +2128,6 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
       }
-    },
-    "google-closure-library": {
-      "version": "20180405.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20180405.0.0.tgz",
-      "integrity": "sha1-wC39D7zVsJE2MM+dEwUKbXa52l0=",
-      "dev": true
     },
     "got": {
       "version": "6.7.1",


### PR DESCRIPTION
When removing, the test for equality should use the comparator. This allows you to use objects as keys.

Example: 

const t = new Tree(function(a,b){return a.c < b.c;});
t.insert({c: 1, d: 2});
t.remove({c: 1, d: 2});
console.log(t.keys()); // prints [ { c: 1, d: 2 } ], should print []