### PR TITLE
Fixed documentation for duplicates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,8 @@
 # Fast splay tree [![npm version](https://badge.fury.io/js/splaytree.svg)](https://badge.fury.io/js/splaytree) [![build](https://travis-ci.org/w8r/splay-tree.svg?branch=master)](https://travis-ci.org/w8r/splay-tree)
 
 [Splay-tree](https://en.wikipedia.org/wiki/Splay_tree): **[fast](#benchmarks)**(non-recursive) and **simple**(< 1000 lines of code)
-Implementation is adapted directly from Wikipedia with the same API as [w8r/avl](https://github.com/w8r/avl), to run the benchmarks agains other trees.
+Implementation is adapted directly from Wikipedia with the same API as [w8r/avl](https://github.com/w8r/avl), to run the benchmarks against other trees.
+
 
 This tree is based on **top-down** splaying algorithm by D.Sleator. It supports
  - splitting, merging
@@ -45,8 +46,9 @@ Or use the compiled version 'dist/splay.js'.
 
 ## API
 
-* `new SplayTree([comparator], [noDuplicates:Boolean])`, where `comparator` is optional comparison function
-* `tree.insert(key:any, [data:any]):Node` - Insert item
+* `new SplayTree([comparator])`, where `comparator` is optional comparison function
+* `tree.insert(key:any, [data:any]):Node` - Insert item, allow duplicate keys
+* `tree.add(key:any, [data:any]):Node` - Insert item if it is not present
 * `tree.remove(key:any):Boolean` - Remove item
 * `tree.removeNode(Node:any)|Boolean` - Remove node
 * `tree.find(key):Node|Null` - Return node by its key
@@ -81,13 +83,9 @@ Or use the compiled version 'dist/splay.js'.
 
  **Duplicate keys**
 
- By default, tree allows duplicate keys. You can disable that by passing `true`
- as a second parameter to the tree constructor. In that case if you would try to
- instert an item with the key, that is already present in the tree, it will not
- be inserted.
- However, the default behavior allows for duplicate keys, cause there are cases
- where you cannot predict that the keys would be unique (example: overlapping
+* `insert()` method allows duplicate keys. This can be useful in certain applications (example: overlapping
  points in 2D).
+* `add()` method will not allow duplicate keys - if key is already present in the tree, no new node is created
 
 ## Example
 
@@ -184,7 +182,7 @@ Bulk-update (10%) of 10000
 ```
 
 Adding google closure library to the benchmark is, of course, unfair, cause the
-node.js version of it is not optimised by the compiler, but in this case it
+node.js version of it is not optimized by the compiler, but in this case it
 plays the role of straight-forward robust implementation.
 
 ## Develop


### PR DESCRIPTION
Looks like it's no longer used. I removed it from the readme file. Hope this works!