### PR TITLE
Export es5 even for output with es2015 modules

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ export default [{
     file: esmBundle,
     sourcemap: true
   },
-  plugins: [typescript({ outDir: "dist" })]
+  plugins: [typescript({ outDir: "dist", module: 'es2015' })]
 }, {
   input: './src/index.ts',
   output: {
@@ -40,7 +40,7 @@ export default [{
   },
   plugins: [typescript({
     tsconfigOverride: {
-      compilerOptions: { outDir: "dist", target: 'es5' }
+      compilerOptions: { outDir: "dist" }
     }
   })]
 }];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "noEmitOnError": true,
     "importHelpers": true,
     "lib": ["es5", "es6", "dom"],
-    "target": "es6",
+    "target": "es5",
     "moduleResolution": "node"
   },
   "target": "ESNext",


### PR DESCRIPTION
Fixes: https://github.com/w8r/splay-tree/issues/15

Changes Typescript target to es5 everywhere to help prevent es6 syntax from sneaking into consumer's bundles.